### PR TITLE
Add form dependencies

### DIFF
--- a/.cirro/process-form.json
+++ b/.cirro/process-form.json
@@ -29,13 +29,26 @@
                             "GRCh38",
                             "Custom"
                         ]
-                    },
-                    "fasta": {
-                        "type": "string",
-                        "title": "Custom Reference Genome (FASTA).",
-                        "help_text": "This parameter is *mandatory* if `--genome` is not specified. If you don't have a BWA index available this will be generated for you automatically. Combine with `--save_reference` to save BWA index for future runs.",
-                        "pathType": "references",
-                        "file": "**/genome_fasta/**/genome.fasta"
+                    }
+                },
+                "dependencies": {
+                    "genome": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "genome": {
+                                        "enum": ["Custom"]
+                                    },
+                                    "fasta": {
+                                        "type": "string",
+                                        "title": "Custom Reference Genome (FASTA).",
+                                        "help_text": "This parameter is *mandatory* if `--genome` is not specified. If you don't have a BWA index available this will be generated for you automatically. Combine with `--save_reference` to save BWA index for future runs.",
+                                        "pathType": "references",
+                                        "file": "**/genome_fasta/**/genome.fasta"
+                                    }
+                                }
+                            }
+                        ]
                     }
                 }
             },
@@ -152,17 +165,39 @@
                 "title": "Cell annotations parameters",
                 "type": "object",
                 "properties": {
-                    "input_cell_markers_db": {
-                        "type": "string",
-                        "pathType": "references",
-                        "file": "**/spreadsheet_csv/**/spreadsheet.csv",
-                        "title": "Cell annotation CSV file (optional)"
-                    },
                     "input_annotation_level": {
                         "type": "string",
                         "default": "Major cells",
                         "title": "Annotation Level",
                         "enum": ["Major cells"]
+                    },
+                    "input_cell_markers_db_source": {
+                        "type": "string",
+                        "title": "Input Cell Markers",
+                        "enum": [
+                            "Default",
+                            "Custom"
+                        ],
+                        "default": "Default"
+                    }
+                },
+                "dependencies": {
+                    "input_cell_markers_db_source": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "input_cell_markers_db_source": {
+                                        "enum": ["Custom"]
+                                    },
+                                    "input_cell_markers_db": {
+                                        "type": "string",
+                                        "pathType": "references",
+                                        "file": "**/spreadsheet_csv/**/spreadsheet.csv",
+                                        "title": "Cell annotation CSV file (optional)"
+                                    }
+                                }
+                            }
+                        ]
                     }
                 }
             },
@@ -237,12 +272,6 @@
                 "title": "Meta-program parameters",
                 "type": "object",
                 "properties": {
-                    "input_meta_programs_db": {
-                        "type": "string",
-                        "pathType": "references",
-                        "file": "**/spreadsheet_csv/**/spreadsheet.csv",
-                        "title": "Meta-program CSV file (optional)"
-                    },
                     "input_cell_category": {
                         "type": "string",
                         "default": "Malignant",
@@ -252,6 +281,34 @@
                         "type": "string",
                         "default": "source_name;seurat_clusters",
                         "title": "Meta-data columns to be displayed on heatmap"
+                    },
+                    "input_meta_programs_db_source": {
+                        "type": "string",
+                        "title": "Input Meta-Programs",
+                        "enum": [
+                            "Default",
+                            "Custom"
+                        ],
+                        "default": "Default"
+                    }
+                },
+                "dependencies": {
+                    "input_meta_programs_db_source": {
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "input_meta_programs_db_source": {
+                                        "enum": ["Custom"]
+                                    },
+                                    "input_meta_programs_db": {
+                                        "type": "string",
+                                        "pathType": "references",
+                                        "file": "**/spreadsheet_csv/**/spreadsheet.csv",
+                                        "title": "Meta-program CSV file (optional)"
+                                    }
+                                }
+                            }
+                        ]
                     }
                 }
             }

--- a/.cirro/process-input.json
+++ b/.cirro/process-input.json
@@ -4,6 +4,7 @@
     "project_name": "$.params.dataset.s3|/data/",
     "cancer_type": "$.params.dataset.paramJson.project_parameters.cancer_type",
     "genome": "$.params.dataset.paramJson.project_parameters.genome",
+    "fasta": "$.params.dataset.paramJson.project_parameters.fasta",
     "thr_estimate_n_cells": "$.params.dataset.paramJson.quality_control_parameters.thr_estimate_n_cells",
     "thr_mean_reads_per_cells": "$.params.dataset.paramJson.quality_control_parameters.thr_mean_reads_per_cells",
     "thr_median_genes_per_cell": "$.params.dataset.paramJson.quality_control_parameters.thr_median_genes_per_cell",
@@ -22,6 +23,7 @@
     "thr_cluster_size": "$.params.dataset.paramJson.stratification_parameters.thr_cluster_size",
     "thr_consensus_score": "$.params.dataset.paramJson.stratification_parameters.thr_consensus_score",
     "input_annotation_level": "$.params.dataset.paramJson.cell_annotations_parameters.input_annotation_level",
+    "input_cell_markers_db": "$.params.dataset.paramJson.cell_annotations_parameters.input_cell_markers_db",
     "input_integration_method": "$.params.dataset.paramJson.batch_correction_parameters.input_integration_method",
     "input_target_variables": "$.params.dataset.paramJson.batch_correction_parameters.input_target_variables",
     "input_integration_evaluate": "$.params.dataset.paramJson.batch_evaluation_parameters.input_integration_evaluate",
@@ -33,5 +35,6 @@
     "thr_min_percentage": "$.params.dataset.paramJson.differential_expression_parameters.thr_min_percentage",
     "opt_hgv_filter": "$.params.dataset.paramJson.differential_expression_parameters.opt_hgv_filter",
     "input_cell_category": "$.params.dataset.paramJson.meta_program_parameters.input_cell_category",
-    "input_heatmap_annotation": "$.params.dataset.paramJson.meta_program_parameters.input_heatmap_annotation"
+    "input_heatmap_annotation": "$.params.dataset.paramJson.meta_program_parameters.input_heatmap_annotation",
+    "input_meta_programs_db": "$.params.dataset.paramJson.meta_program_parameters.input_meta_programs_db"
 }


### PR DESCRIPTION
Here is an example of how you set up form elements which are dependent on the selections of other elements. For example, if `genome` is selected as `Custom`, then the user will have an opportunity to select an uploaded reference file for `fasta`. If they select `GRCh38`, then the `fasta` parameter will be omitted. I think this should work for the behavior that we've discussed. If this looks right, merge the PR and update the process configuration in Cirro from the updated repo.