### PR TITLE
Add fallback cases for each oneOf dependency

### DIFF
--- a/.cirro/process-form.json
+++ b/.cirro/process-form.json
@@ -47,6 +47,13 @@
                                         "file": "**/genome_fasta/**/genome.fasta"
                                     }
                                 }
+                            },
+                            {
+                                "properties": {
+                                    "genome": {
+                                        "enum": ["GRCh38"]
+                                    }
+                                }
                             }
                         ]
                     }
@@ -196,6 +203,13 @@
                                         "title": "Cell annotation CSV file (optional)"
                                     }
                                 }
+                            },
+                            {
+                                "properties": {
+                                    "input_cell_markers_db_source": {
+                                        "enum": ["Default"]
+                                    }
+                                }
                             }
                         ]
                     }
@@ -305,6 +319,13 @@
                                         "pathType": "references",
                                         "file": "**/spreadsheet_csv/**/spreadsheet.csv",
                                         "title": "Meta-program CSV file (optional)"
+                                    }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "input_meta_programs_db_source": {
+                                        "enum": ["Default"]
                                     }
                                 }
                             }


### PR DESCRIPTION
This should fulfill the expectations of the form when the default option is selected. The `dependency` is expecting one of the defined cases to match the inputs, which is what this should now provide.