### PR TITLE
Add the outdir param

### DIFF
--- a/.cirro/preprocess.py
+++ b/.cirro/preprocess.py
@@ -51,7 +51,9 @@ def setup_input_parameters(ds: PreprocessDataset):
     # If the user selects a "Custom" genome,
     # then the `fasta` parameter will be used
     if ds.params["genome"] == "Custom":
-        ds.remove_param("genome")
+        # Set params.genome to False
+        ds.add_param("genome", False, overwrite=True)
+        # Make sure that params.fasta was provided by the user
         msg = "Must provide custom genome FASTA from references"
         assert ds.params.get("fasta") is not None, msg
 

--- a/.cirro/process-input.json
+++ b/.cirro/process-input.json
@@ -2,6 +2,7 @@
     "sample_table": "sample_table.csv",
     "meta_data": "meta_data.csv",
     "project_name": "$.params.dataset.s3|/data/",
+    "outdir": "$.params.dataset.s3|/data/",
     "cancer_type": "$.params.dataset.paramJson.project_parameters.cancer_type",
     "genome": "$.params.dataset.paramJson.project_parameters.genome",
     "fasta": "$.params.dataset.paramJson.project_parameters.fasta",


### PR DESCRIPTION
I noticed in the logs that the workflow was expecting the `outdir` param, and so I added it to the preprocess script.

I also modified the behavior with the `genome` parameter slightly so that it is always initialized, even in the case when it is set to False and a custom genome is being used.