### PR TITLE
Hardcode publishDir.mode = 'copy'

### DIFF
--- a/.cirro/process-compute.config
+++ b/.cirro/process-compute.config
@@ -2,4 +2,9 @@ process {
     executor = 'awsbatch'
     errorStrategy = 'retry'
     maxRetries = 2
+
+    publishDir = [
+        mode: 'copy'
+    ]
+
 }


### PR DESCRIPTION
I'm not totally sure this will work, but I think that any configuration defined in this scope should take precedence over the settings in the module itself (based on https://www.nextflow.io/docs/latest/config.html)